### PR TITLE
Bumped Crystal version to 1.0.0.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.13.0
+    version: ~> 0.14.2
 
 crystal: 1.0.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 0.13.0
 
-crystal: ">= 0.33.0"
+crystal: 1.0.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 0.14.2
 
-crystal: 1.0.0
+crystal: ">= 0.33.0, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
`awscr-s3` (https://github.com/taylorfinnell/awscr-s3) depends from `timecop.cr` and shrine.cr (https://github.com/jetrockets/shrine.cr) depends from `awscr-s3`.

Lets bump supported Crystal version to resolve all dependencies.