### PR TITLE
Fixed required Crystal version to support Crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 0.13.0
 
-crystal: ">= 0.33.0"
+crystal: ">= 0.33.0, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
Created new PR instead of https://github.com/crystal-community/timecop.cr/pull/6.