### PR TITLE
tick version to 0.5.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: timecop
-version: 0.4.1
+version: 0.5.0
 
 authors:
   - TobiasGSmollett <landofscala@gmail.com>

--- a/src/timecop/version.cr
+++ b/src/timecop/version.cr
@@ -1,3 +1,3 @@
 module Timecop
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
fixes #8 

The fix code is already in master, unreleased.

I chose to increment a minor version rather than a patch because the previous release didn't mock out monotonic, which means that #measure didn't work as it should. This is technically a bug-fix but it's entirely possible there are folks who have written code around the buggy nature.