### PR TITLE
Updates for Crystal 1.19 compatibility

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,6 @@ development_dependencies:
     github: crystal-ameba/ameba
     version: ~> 1.3.0
 
-crystal: ">= 0.33.0"
+crystal: ">= 1.19.1"
 
 license: MIT

--- a/spec/timecop_spec.cr
+++ b/spec/timecop_spec.cr
@@ -94,6 +94,29 @@ describe Timecop do
         end
       end
     end
+
+    context "instant" do
+      it "prevents moving time elapsed" do
+        time = Time.local(2008, 10, 10, 10, 10, 10)
+
+        Timecop.freeze(time) do
+          start = Time.instant
+          sleep(250.milliseconds)
+          start.elapsed.should be_close(Time::Span.zero, 1.milliseconds)
+        end
+      end
+
+      it "changes the time elapsed" do
+        time = Time.local(2008, 10, 10, 10, 10, 10)
+        elapsed = 5.minutes
+
+        Timecop.freeze(time) do
+          start = Time.instant
+          Timecop.freeze(time + elapsed)
+          (Time.instant - start).should be_close(elapsed, 1.milliseconds)
+        end
+      end
+    end
   end
 
   context ".scale" do
@@ -119,6 +142,17 @@ describe Timecop do
           start = Time.monotonic
           sleep(250.milliseconds)
           (start + 1.second).should be_close(Time.monotonic, 250.milliseconds)
+        end
+      end
+    end
+
+    context "instant" do
+      it "keeps time moving at an accelerated rate" do
+        time = Time.local(2008, 10, 10, 10, 10, 10)
+        Timecop.scale(time, 4) do
+          start = Time.instant
+          sleep(250.milliseconds)
+          start.elapsed.should be_close(1.second, 250.milliseconds)
         end
       end
     end
@@ -152,6 +186,17 @@ describe Timecop do
           finish = Time.monotonic
           elapsed = finish - start
           elapsed.should_not be_close(finish, 240.milliseconds)
+        end
+      end
+    end
+
+    context "instant" do
+      it "keeps time moving" do
+        time = Time.local(2008, 10, 10, 10, 10, 10)
+        Timecop.travel(time) do
+          start = Time.instant
+          sleep(250.milliseconds)
+          start.elapsed.should be_close(250.milliseconds, 50.milliseconds)
         end
       end
     end

--- a/src/timecop/core_ext/time.cr
+++ b/src/timecop/core_ext/time.cr
@@ -16,6 +16,13 @@ struct Time
     @@mock = true
   end
 
+  def self.instant_without_mock_time : Time::Instant
+    @@mock = false
+    instant
+  ensure
+    @@mock = true
+  end
+
   def self.local(location : Location = Location.local) : Time
     return previous_def if !Timecop.frozen? || !@@mock
     Timecop.top_stack_item.time(location)
@@ -29,5 +36,10 @@ struct Time
   def self.monotonic : Time::Span
     return previous_def if !Timecop.frozen? || !@@mock
     Timecop.top_stack_item.monotonic
+  end
+
+  def self.instant : Time::Instant
+    return previous_def if !Timecop.frozen? || !@@mock
+    Timecop.top_stack_item.instant
   end
 end

--- a/src/timecop/time_stack_item.cr
+++ b/src/timecop/time_stack_item.cr
@@ -13,10 +13,12 @@ module Timecop
 
     @prev_time : Time
     @monotonic : Time::Span
+    @instant : Time::Instant
 
     def initialize(@mock_type : MockType, @time : Time, @scaling_factor : Float64 = 1.0)
       @prev_time = Time.local_without_mock_time
       @monotonic = Time.monotonic_without_mock_time
+      @instant = Time.instant_without_mock_time
     end
 
     def initialize(@mock_type : MockType, @scaling_factor : Float64 = 1.0)
@@ -50,6 +52,22 @@ module Timecop
       when .scale?
         diff = Time.monotonic_without_mock_time - @monotonic
         @monotonic + (diff * @scaling_factor)
+      else
+        raise "Unknown mock_type #{@mock_type}"
+      end
+    end
+
+    # :nodoc:
+    def instant : Time::Instant
+      case @mock_type
+      when .freeze?
+        @instant + (@time - @prev_time)
+      when .travel?
+        offset = @time - @prev_time
+        Time.instant_without_mock_time + offset
+      when .scale?
+        diff = Time.instant_without_mock_time - @instant
+        @instant + (diff * @scaling_factor)
       else
         raise "Unknown mock_type #{@mock_type}"
       end


### PR DESCRIPTION
This isn't a breaking release in the sense that I didn't remove monotonic, but it won't compile under previous versions of crystal because it uses Time.instant. I'd recommend releasing it as 0.6.0.

fixes #13 